### PR TITLE
Adds adapters for solving std::array and raw (C-style) array.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ DIST_LIBDIR = $(INSTALLDIR)/lib/
 SOURCES = munkres.cpp
 OBJECTS := $(patsubst %.cpp,%.o,$(SOURCES))
 HEADERS := $(filter-out main.h,$(patsubst %.cpp,%.h,$(SOURCES))) matrix.h matrix.cpp
-UNITTESTS = ../tests/munkrestest.cpp ../tests/matrixtest.cpp
+UNITTESTS = ../tests/munkrestest.cpp ../tests/matrixtest.cpp ../tests/adapterstest.cpp
 LDPATH =
 LDADD = -lgcov -lgtest -lgtest_main -lpthread
 

--- a/src/adapters.cpp
+++ b/src/adapters.cpp
@@ -1,0 +1,86 @@
+/*
+ *   Copyright (c) 2007 John Weaver
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ */
+
+#include "adapters.h"
+#include "munkres.h"
+
+template <typename T, const unsigned int dimention>
+Matrix <T> convert_std_2d_array_to_munkres_matrix (const std::array <std::array <T, dimention>, dimention> & array)
+{
+  Matrix <T> matrix (dimention, dimention);
+  for (int i = 0; i < dimention; ++i) {
+    for (int j = 0; j < dimention; ++j) {
+      matrix (i, j) = array [i][j];
+    }
+  }
+
+  return matrix;
+};
+
+template <typename T, const unsigned int dimention>
+void fill_std_2d_array_from_munkres_matrix (std::array <std::array <T, dimention>, dimention> & array, const Matrix <T> & matrix)
+{
+  for (int i = 0; i < dimention; ++i) {
+    for (int j = 0; j < dimention; ++j) {
+      array [i][j] = matrix (i, j);
+    }
+  }
+};
+
+template <const unsigned int dimension>
+void solve(std::array <std::array <double, dimension>, dimension> &m)
+{
+  auto matrix = convert_std_2d_array_to_munkres_matrix<double, dimension>(m);
+  Munkres munkres;
+  munkres.solve (matrix);
+  fill_std_2d_array_from_munkres_matrix<double, dimension>(m, matrix);
+};
+
+
+
+template <typename T, const unsigned int dimention>
+Matrix <T> convert_raw_2d_array_to_munkres_matrix (const T array [dimention][dimention])
+{
+  Matrix <T> matrix (dimention, dimention);
+  for (int i = 0; i < dimention; ++i) {
+    for (int j = 0; j < dimention; ++j) {
+      matrix (i, j) = array [i][j];
+    }
+  }
+
+  return matrix;
+};
+
+template <typename T, const unsigned int dimention>
+void fill_raw_2d_array_from_munkres_matrix (T array [dimention][dimention], const Matrix <T> & matrix)
+{
+  for (int i = 0; i < dimention; ++i) {
+    for (int j = 0; j < dimention; ++j) {
+      array [i][j] = matrix (i, j);
+    }
+  }
+};
+
+template <const unsigned int dimension>
+void solve(double m [dimension][dimension])
+{
+  auto matrix = convert_raw_2d_array_to_munkres_matrix<double, dimension>(m);
+  Munkres munkres;
+  munkres.solve (matrix);
+  fill_raw_2d_array_from_munkres_matrix<double, dimension>(m, matrix);
+};

--- a/src/adapters.h
+++ b/src/adapters.h
@@ -1,0 +1,53 @@
+/*
+ *   Copyright (c) 2007 John Weaver
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ */
+
+#if !defined(_MUNKRES_ADAPTERS_H_)
+#define _MUNKRES_ADAPTERS_H_
+
+#include "matrix.h"
+#include <array>
+
+
+// Set of functions for two-dimensional std::array.
+template <typename T, const unsigned int dimention>
+Matrix <T> convert_std_2d_array_to_munkres_matrix (const std::array <std::array <T, dimention>, dimention> & array);
+
+template <typename T, const unsigned int dimention>
+void fill_std_2d_array_from_munkres_matrix (std::array <std::array <T, dimention>, dimention> & array, const Matrix <T> & matrix);
+
+template <const unsigned int dimension>
+void solve(std::array <std::array <double, dimension>, dimension> &m);
+
+
+
+// Set of functions for two-dimensional raw (C-style) array.
+template <typename T, const unsigned int dimention>
+Matrix <T> convert_raw_2d_array_to_munkres_matrix (const T array [dimention][dimention]);
+
+template <typename T, const unsigned int dimention>
+void fill_raw_2d_array_from_munkres_matrix (T array [dimention][dimention], const Matrix <T> & matrix);
+
+template <const unsigned int dimension>
+void solve(double m [dimension][dimension]);
+
+#ifndef USE_EXPORT_KEYWORD
+#include "adapters.cpp"
+//#define export /*export*/
+#endif
+
+#endif /* !defined(_MUNKRES_ADAPTERS_H_) */

--- a/tests/adapterstest.cpp
+++ b/tests/adapterstest.cpp
@@ -1,0 +1,188 @@
+#include <gtest/gtest.h>
+#include "adapters.h"
+#include <iostream>
+#include <iomanip>
+
+
+
+class AdaptersTest : public ::testing::Test
+{
+};
+
+
+
+TEST_F (AdaptersTest, convert_std_2d_array_to_munkres_matrix_Success)
+{
+  // Arrange.
+  constexpr unsigned int dimension {3};
+  const std::array <std::array <double, dimension>, dimension> test_array {{
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9}
+  }};
+  const Matrix <double> etalon_matrix {
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9}
+  };
+
+  // Act.
+  const auto test_matrix = convert_std_2d_array_to_munkres_matrix <double, test_array.size ()> (test_array);
+
+  // Assert.
+  for (unsigned int row = 0; row < dimension; ++row) {
+    for (unsigned int col = 0; col < dimension; ++col) {
+      EXPECT_EQ (etalon_matrix (row, col), test_matrix (row, col) );
+    }
+  }
+}
+
+
+
+TEST_F (AdaptersTest, fill_std_2d_array_from_munkres_matrix_Success)
+{
+  // Arrange.
+  constexpr unsigned int dimension {3};
+  std::array <std::array <double, dimension>, dimension> test_array {{
+    {0, 0, 0},
+    {0, 0, 0},
+    {0, 0, 0}
+  }};
+  const std::array <std::array <double, dimension>, dimension> etalon_array {{
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9}
+  }};
+  const Matrix <double> etalon_matrix {
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9}
+  };
+
+  // Act.
+  fill_std_2d_array_from_munkres_matrix <double, dimension> (test_array, etalon_matrix);
+
+  // Assert.
+  for (unsigned int row = 0; row < dimension; ++row) {
+    for (unsigned int col = 0; col < dimension; ++col) {
+      EXPECT_EQ (etalon_array [row][col], test_array [row][col]);
+    }
+  }
+}
+
+
+
+TEST_F (AdaptersTest, solve_std_2d_array_Success)
+{
+  // Arrange.
+  constexpr unsigned int dimension {3};
+  std::array <std::array <double, dimension>, dimension> etalon_array{{
+    {-1.0,  0.0, -1.0},
+    { 0.0, -1.0, -1.0},
+    {-1.0, -1.0,  0.0}
+  }};
+  std::array <std::array <double, dimension>, dimension> test_array{{
+    {1.0,  0.0,  1.0},
+    {0.0,  1.0,  1.0},
+    {1.0,  1.0,  0.0}
+  }};
+
+  // Act.
+  solve <dimension> (test_array);
+
+  // Assert.
+  for (unsigned int row = 0; row < dimension; ++row) {
+    for (unsigned int col = 0; col < dimension; ++col) {
+      EXPECT_EQ (etalon_array [row][col], test_array [row][col]);
+    }
+  }
+}
+
+
+
+TEST_F (AdaptersTest, convert_raw_2d_array_to_munkres_matrix_Success)
+{
+  // Arrange.
+  constexpr unsigned int dimension {3};
+  const double test_array [dimension][dimension] {
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9}
+  };
+  const Matrix <double> etalon_matrix {
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9}
+  };
+
+  // Act.
+  const auto test_matrix = convert_raw_2d_array_to_munkres_matrix <double, dimension> (test_array);
+
+  // Assert.
+  for (unsigned int row = 0; row < dimension; ++row) {
+    for (unsigned int col = 0; col < dimension; ++col) {
+      EXPECT_EQ (etalon_matrix (row, col), test_matrix (row, col) );
+    }
+  }
+}
+
+
+
+TEST_F (AdaptersTest, fill_raw_2d_array_from_munkres_matrix_Success)
+{
+  // Arrange.
+  constexpr unsigned int dimension {3};
+  double test_array [dimension][dimension] {
+    {0, 0, 0},
+    {0, 0, 0},
+    {0, 0, 0}
+  };
+  const double etalon_array [dimension][dimension] {
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9}
+  };
+  const Matrix <double> etalon_matrix {
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9}
+  };
+
+  // Act.
+  fill_raw_2d_array_from_munkres_matrix <double, dimension> (test_array, etalon_matrix);
+
+  // Assert.
+  for (unsigned int row = 0; row < dimension; ++row) {
+    for (unsigned int col = 0; col < dimension; ++col) {
+      EXPECT_EQ (etalon_array [row][col], test_array [row][col]);
+    }
+  }
+}
+
+
+
+TEST_F (AdaptersTest, solve_raw_2d_array_Success)
+{
+  // Arrange.
+  constexpr unsigned int dimension {3};
+  double etalon_array [dimension][dimension]{
+    {-1.0,  0.0, -1.0},
+    { 0.0, -1.0, -1.0},
+    {-1.0, -1.0,  0.0}
+  };
+  double test_array [dimension][dimension]{
+    {1.0,  0.0,  1.0},
+    {0.0,  1.0,  1.0},
+    {1.0,  1.0,  0.0}
+  };
+
+  // Act.
+  solve <dimension> (test_array);
+
+  // Assert.
+  for (unsigned int row = 0; row < dimension; ++row) {
+    for (unsigned int col = 0; col < dimension; ++col) {
+      EXPECT_EQ (etalon_array [row][col], test_array [row][col]);
+    }
+  }
+}


### PR DESCRIPTION
This commit is related to the issue #6 (Support other matrix data type classes).
